### PR TITLE
Show loading overlay on passwordreset verification

### DIFF
--- a/src/app/components/account/account.module.ts
+++ b/src/app/components/account/account.module.ts
@@ -24,6 +24,7 @@ import {EmailChangeComponent} from './account-profile/email-change/email-change.
 import {EmailChangeModule} from './account-profile/email-change/email-change.module';
 import {LogoutComponent} from './main/logout/logout.component';
 import {AuthGuard} from '../../_helper/auth.guard';
+import {LoadingModule} from '../html-template/loading/loading.module';
 
 
 const routes: Routes = [
@@ -62,7 +63,8 @@ const routes: Routes = [
     UserDataModule,
     SavedModule,
     EmailChangeModule,
-    MatListModule
+    MatListModule,
+    LoadingModule
   ],
   providers: [
     ValidatorService

--- a/src/app/components/account/main/passwordreset/passwordreset.component.html
+++ b/src/app/components/account/main/passwordreset/passwordreset.component.html
@@ -1,4 +1,4 @@
-<mat-card class="form float">
+<mat-card *ngIf="this.validated; else loadingTmpl" class="form float">
   <mat-card-title *ngIf="this.error === null"
                   class="headline">
     Passwort vergessen
@@ -94,5 +94,10 @@
 
 <ng-template #err>
   <span>{{error}}</span>
+</ng-template>
+
+<ng-template #loadingTmpl>
+  <app-loading [@remove]>
+  </app-loading>
 </ng-template>
 

--- a/src/app/components/account/main/passwordreset/passwordreset.component.ts
+++ b/src/app/components/account/main/passwordreset/passwordreset.component.ts
@@ -5,6 +5,7 @@ import {FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators} from 
 import {DatePipe} from '@angular/common';
 import {HttpEventType} from '@angular/common/http';
 import {ValidatorService} from '../../../../_helper/validatorService';
+import {animate, query, style, transition, trigger} from '@angular/animations';
 
 const HttpStatus = require('http-status-codes');
 
@@ -22,7 +23,17 @@ export function passwordVerifyCheck(): ValidatorFn {
 @Component({
   selector: 'app-passwordreset',
   templateUrl: './passwordreset.component.html',
-  styleUrls: ['./passwordreset.component.scss']
+  styleUrls: ['./passwordreset.component.scss'],
+  animations: [
+    trigger('remove', [
+      transition('* => void', [
+        query('.layer', [
+          style({opacity: '1'}),
+          animate(500, style({opacity: '0'}))
+        ])
+      ])
+    ])
+  ]
 })
 export class PasswordresetComponent implements OnInit {
   public done = false;
@@ -40,8 +51,10 @@ export class PasswordresetComponent implements OnInit {
       passwordVerify: new FormControl('', [Validators.required]),
     }, passwordVerifyCheck()),
   });
+
   public doneMsg: string;
   private date: any;
+  private validated = false;
 
   constructor(private route: ActivatedRoute, private accountService: AccountService,
               private validatorService: ValidatorService) {
@@ -60,8 +73,8 @@ export class PasswordresetComponent implements OnInit {
       await this.accountService
         .validatePasswordresetToken(this.mail, this.token)
         .subscribe(
-          result => {
-            console.log(result);
+          () => {
+            this.validated = true;
           },
           error => {
             let message = '';
@@ -86,10 +99,13 @@ export class PasswordresetComponent implements OnInit {
                   break;
               }
 
+              this.validated = true;
               this.error = message;
             }
           }
         );
+    } else {
+      this.validated = true;
     }
   }
 

--- a/src/app/components/html-template/loading/loading.component.scss
+++ b/src/app/components/html-template/loading/loading.component.scss
@@ -16,7 +16,7 @@ div {
 
     div {
       background-color: transparent;
-      width: 100%;
+      width: calc(100% - 50px);
       height: auto;
       top: 50%;
       transform: translateY(-50%);


### PR DESCRIPTION
When opening the password reset link sent via email, the link needs to be validated first. In this time, instead of switching templates, the overlay takes care of not leaving the user in the dark.