### PR TITLE
Auto pinning showing 'Angepinnt multiple times

### DIFF
--- a/src/app/components/termin/appointment.component.ts
+++ b/src/app/components/termin/appointment.component.ts
@@ -149,6 +149,8 @@ export class AppointmentComponent implements OnInit, OnDestroy {
                   });
               }
 
+              sAppointment.reference.push('PINNED');
+
               this.snackBar.open('Angepinnt',
                 '',
                 {


### PR DESCRIPTION
Upon navigation to a appointment from the dashboard multiple times without reloading the snackBar "Angepinned" is showing multiple times. 

This is due to the check for the PINNED reference of the appointment always returning true.
Fiyed by adding "PINNED" to the appointment reference on auto-pin

Close #85