### PR TITLE
Fix show error on duplicate name at enrollment

### DIFF
--- a/src/app/components/termin/enrollment/enrollment.component.html
+++ b/src/app/components/termin/enrollment/enrollment.component.html
@@ -38,7 +38,7 @@
                          placeholder="Name"
                          required>
                 </label>
-                <mat-error *ngIf="getName().invalid">
+                <mat-error>
                   {{ getNameErrorMessage() }}
                 </mat-error>
               </mat-form-field>
@@ -190,7 +190,7 @@
               {{ getMailErrorMessage() }}
             </mat-error>
           </mat-form-field>
-          <button (click)="sendEnrollment()"
+          <button (click)="mailFormComplete()"
                   mat-raised-button>
             Absenden
           </button>


### PR DESCRIPTION
When being not logged in and enrollind to an appointment with a name already existing, there was no visible error until the user sends the request again.
Temporary fixed until the entire  structure gets refurbished.

Close #97 