### PR TITLE
Appointment data forms - CSS cleanup

### DIFF
--- a/src/app/components/termin/administrator/administrator.component.html
+++ b/src/app/components/termin/administrator/administrator.component.html
@@ -1,27 +1,33 @@
 <form [formGroup]="event">
+
+  <span class="form-component-title"> Administratoren</span>
+
+  <mat-card-content>
+    <div class="input-with-button-wrapper">
+      <mat-form-field>
+        <input aria-label="Number"
+               formControlName="username"
+               matInput
+               placeholder="Benutzername"
+               type="text">
+      </mat-form-field>
+
+      <button (click)="add()" mat-raised-button>Hinzufügen</button>
+    </div>
+
+    <ng-container *ngIf="administrators.length > 0">
+      <div class="administrator-wrapper">
+        <app-administrator-delete
+          (deleted)="removeAdministrator($event)"
+          *ngFor="let admin of administrators"
+          [admin]="admin"
+          [appointment]="appointment">
+        </app-administrator-delete>
+      </div>
+    </ng-container>
+  </mat-card-content>
+
   <span class="info">
     Erlaube jemandem die Administration dieses Termins
   </span>
-  <div class="input-with-button-wrapper">
-    <mat-form-field>
-      <input aria-label="Number"
-             formControlName="username"
-             matInput
-             placeholder="Benutzername"
-             type="text">
-    </mat-form-field>
-    <button (click)="add()" mat-raised-button>Hinzufügen</button>
-  </div>
-
-  <ng-container *ngIf="administrators.length > 0">
-    <span class="separator center colored middle extra-tall"></span>
-    <div class="administrator-wrapper">
-      <app-administrator-delete
-        *ngFor="let admin of administrators"
-        [admin]="admin"
-        (deleted)="removeAdministrator($event)"
-        [appointment]="appointment">
-      </app-administrator-delete>
-    </div>
-  </ng-container>
 </form>

--- a/src/app/components/termin/administrator/administrator.module.ts
+++ b/src/app/components/termin/administrator/administrator.module.ts
@@ -2,7 +2,7 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {AdministratorComponent} from './administrator.component';
 import {AdministratorDeleteModule} from './administrator-delete/administrator-delete.module';
-import {MatButtonModule, MatFormFieldModule, MatInputModule} from '@angular/material';
+import {MatButtonModule, MatCardModule, MatFormFieldModule, MatInputModule} from '@angular/material';
 import {ReactiveFormsModule} from '@angular/forms';
 
 
@@ -17,7 +17,9 @@ import {ReactiveFormsModule} from '@angular/forms';
     MatButtonModule,
     MatFormFieldModule,
     ReactiveFormsModule,
-    MatInputModule
+    MatInputModule,
+    MatCardModule,
+    MatCardModule
   ]
 })
 export class AdministratorModule {

--- a/src/app/components/termin/appointment-create/appointment-create.component.html
+++ b/src/app/components/termin/appointment-create/appointment-create.component.html
@@ -10,7 +10,7 @@
   <!--    <mat-icon>file_copy</mat-icon>-->
   <!--  </span>-->
 
-  <mat-horizontal-stepper #stepper [selectedIndex]="2" labelPosition="bottom">
+  <mat-horizontal-stepper #stepper labelPosition="bottom" linear>
     <!-- OVERALL DATA-->
     <ng-template matStepperIcon="overall">
       <mat-icon>event</mat-icon>
@@ -64,10 +64,39 @@
       <mat-icon>done_outline</mat-icon>
     </ng-template>
     <mat-step [stepControl]="doneGroup" state="gr">
+      <ng-template matStepLabel>
+        Fertig
+      </ng-template>
       <form [formGroup]="doneGroup">
-        <ng-template matStepLabel>
-          Fertig
-        </ng-template>
+
+        <span class="form-component-title">Fertig?</span>
+
+        <mat-card-content>
+        </mat-card-content>
+
+        <div class="info">
+          Sind alle Daten korrekt?
+        </div>
+
+        <mat-card-actions class="double">
+          <div>
+            <button (click)="back()"
+                    class="left"
+                    color="primary"
+                    disableRipple
+                    mat-button
+                    type="button">
+              Zurück
+            </button>
+          </div>
+          <button
+            (click)="create()"
+            color="primary"
+            mat-raised-button>
+            Erstellen
+          </button>
+        </mat-card-actions>
+
         <!--        <div class="tooltip-container">-->
         <!--          <mat-checkbox formControlName="saveAsTemplate">-->
         <!--            Als Vorlage Speichern-->
@@ -80,11 +109,6 @@
         <!--            info-->
         <!--          </mat-icon>-->
         <!--        </div>-->
-        <button (click)="create()"
-                mat-stroked-button>
-          Erstellen
-        </button>
-        <button mat-button matStepperPrevious>Zurück</button>
       </form>
     </mat-step>
   </mat-horizontal-stepper>

--- a/src/app/components/termin/appointment-create/appointment-create.component.html
+++ b/src/app/components/termin/appointment-create/appointment-create.component.html
@@ -1,14 +1,22 @@
-<mat-card *ngIf="percentDone === 0">
-  <mat-card-title class="headline">
+<mat-card *ngIf="percentDone === 0"
+          class="form float high">
+  <mat-card-title class="headline"
+                  id="title">
     Termin erstellen
   </mat-card-title>
+
   <!--  <span (click)="_openAppointmentTemplateDialog()">-->
   <!--    Vorlagen-->
   <!--    <mat-icon>file_copy</mat-icon>-->
   <!--  </span>-->
-  <mat-vertical-stepper #stepper linear>
+
+  <mat-horizontal-stepper #stepper labelPosition="bottom">
     <!-- OVERALL DATA-->
-    <mat-step>
+    <ng-template matStepperIcon="overall">
+      <mat-icon>event</mat-icon>
+    </ng-template>
+    <mat-step [completed]="doneForms['overall']"
+              state="overall">
       <ng-template matStepLabel>
         Allgemein
       </ng-template>
@@ -19,19 +27,28 @@
     </mat-step>
 
     <!-- ADDITIONS-->
-    <mat-step>
+    <ng-template matStepperIcon="additions">
+      <mat-icon>check_box</mat-icon>
+    </ng-template>
+    <mat-step [completed]="doneForms['additions']"
+              [optional]="true"
+              state="additions">
       <ng-template matStepLabel>
         Zusätze
       </ng-template>
       <app-additions
         (save)="getAdditions($event)"
+        (back)="back()"
         [button]="'Weiter'">
       </app-additions>
-      <button class="stepper-navigation" mat-button matStepperPrevious>Zurück</button>
     </mat-step>
 
     <!-- LINK DATA -->
-    <mat-step>
+    <ng-template matStepperIcon="link">
+      <mat-icon>link</mat-icon>
+    </ng-template>
+    <mat-step [completed]="doneForms['link']"
+              state="link">
       <ng-template matStepLabel>
         Link
       </ng-template>
@@ -43,7 +60,10 @@
     </mat-step>
 
     <!-- DONE -->
-    <mat-step [stepControl]="doneGroup">
+    <ng-template matStepperIcon="gr">
+      <mat-icon>done_outline</mat-icon>
+    </ng-template>
+    <mat-step [stepControl]="doneGroup" state="gr">
       <form [formGroup]="doneGroup">
         <ng-template matStepLabel>
           Fertig
@@ -67,7 +87,7 @@
         <button mat-button matStepperPrevious>Zurück</button>
       </form>
     </mat-step>
-  </mat-vertical-stepper>
+  </mat-horizontal-stepper>
 </mat-card>
 
 <div *ngIf="percentDone !== 0" class="upload-progress">

--- a/src/app/components/termin/appointment-create/appointment-create.component.html
+++ b/src/app/components/termin/appointment-create/appointment-create.component.html
@@ -10,7 +10,7 @@
   <!--    <mat-icon>file_copy</mat-icon>-->
   <!--  </span>-->
 
-  <mat-horizontal-stepper #stepper labelPosition="bottom">
+  <mat-horizontal-stepper #stepper [selectedIndex]="2" labelPosition="bottom">
     <!-- OVERALL DATA-->
     <ng-template matStepperIcon="overall">
       <mat-icon>event</mat-icon>
@@ -54,9 +54,9 @@
       </ng-template>
       <app-link-data
         (save)="getLinkData($event)"
+        (back)="back()"
         [button]="'Weiter'">>
       </app-link-data>
-      <button class="stepper-navigation" mat-button matStepperPrevious>Zurück</button>
     </mat-step>
 
     <!-- DONE -->

--- a/src/app/components/termin/appointment-create/appointment-create.component.scss
+++ b/src/app/components/termin/appointment-create/appointment-create.component.scss
@@ -5,26 +5,44 @@
   line-height: $size;
 }
 
-::ng-deep .mat-vertical-stepper-header {
-  pointer-events: none !important;
-}
+::ng-deep .mat-stepper-horizontal {
+  .mat-horizontal-stepper-header-container {
+    overflow: scroll;
+    margin-bottom: 1.25em;
+  }
 
-.mat-card {
-  margin: 25px auto;
+  .mat-horizontal-stepper-header {
+    overflow: visible;
+    padding: 16px 16px !important;
+    height: auto !important;
 
-  span:first-of-type {
-    display: block;
-    margin: 0 auto;
-    width: fit-content;
+    &:first-of-type {
+      padding-left: 0 !important;
+    }
 
-    mat-icon {
-      @include md-icon-size(1.25em);
+    &:last-of-type {
+      padding-right: 0 !important;
+    }
+
+    &::before {
+      top: 28px !important;
+    }
+
+    &::after {
+      top: 28px !important;
     }
   }
-}
 
-.mat-form-field {
-  font-size: 0.8em;
+  .mat-stepper-horizontal-line {
+  }
+
+  //.mat-vertical-horizontal-header {
+  //  pointer-events: none !important;
+  //}
+
+  .mat-horizontal-content-container {
+    padding: 0 0 0 0;
+  }
 }
 
 .stepper-navigation {

--- a/src/app/components/termin/appointment-create/appointment-create.component.scss
+++ b/src/app/components/termin/appointment-create/appointment-create.component.scss
@@ -7,7 +7,7 @@
 
 ::ng-deep .mat-stepper-horizontal {
   .mat-horizontal-stepper-header-container {
-    overflow: scroll;
+    overflow: auto;
     margin-bottom: 1.25em;
   }
 

--- a/src/app/components/termin/appointment-create/appointment-create.component.ts
+++ b/src/app/components/termin/appointment-create/appointment-create.component.ts
@@ -24,6 +24,7 @@ export class AppointmentCreateComponent implements OnInit {
   public output: any = {};
   public percentDone = 0;
   public stepValid = [false, false, false];
+  doneForms = {overall: false, additions: false, link: false};
 
   constructor(private formBuilder: FormBuilder,
               public dialog: MatDialog, private appointmentService: AppointmentService,
@@ -34,9 +35,34 @@ export class AppointmentCreateComponent implements OnInit {
     });
   }
 
-
   ngOnInit() {
   }
+
+  // Dialogs
+  // public _openAppointmentTemplateDialog: () => void = () => {
+  //   const dialogRef = this.dialog.open(TemplateDialogComponent, {
+  //     width: '90%',
+  //     maxWidth: '500px',
+  //     height: 'auto',
+  //     maxHeight: '80vh',
+  //   });
+  //
+  //   dialogRef.afterClosed().subscribe(result => {
+  //     if (isObject(result)) {
+  // this.overallDataFormGroup.get('title').setValue(result.title);
+  // this.overallDataFormGroup.get('location').setValue(result.location);
+  // this.overallDataFormGroup.get('maxEnrollments').setValue(result.maxEnrollments);
+  //
+  // this.linkFormGroup.get('description').setValue(result.description);
+  // result.additions.forEach(addition => {
+  //   // add additions
+  // });
+  //
+  // this.getDriverAddition().setValue(result.driverAddition);
+  //     }
+  //   });
+  // };
+
 
   async create() {
     this.output.administrators = [];
@@ -78,31 +104,6 @@ export class AppointmentCreateComponent implements OnInit {
       );
   }
 
-  // Dialogs
-  // public _openAppointmentTemplateDialog: () => void = () => {
-  //   const dialogRef = this.dialog.open(TemplateDialogComponent, {
-  //     width: '90%',
-  //     maxWidth: '500px',
-  //     height: 'auto',
-  //     maxHeight: '80vh',
-  //   });
-  //
-  //   dialogRef.afterClosed().subscribe(result => {
-  //     if (isObject(result)) {
-  // this.overallDataFormGroup.get('title').setValue(result.title);
-  // this.overallDataFormGroup.get('location').setValue(result.location);
-  // this.overallDataFormGroup.get('maxEnrollments').setValue(result.maxEnrollments);
-  //
-  // this.linkFormGroup.get('description').setValue(result.description);
-  // result.additions.forEach(addition => {
-  //   // add additions
-  // });
-  //
-  // this.getDriverAddition().setValue(result.driverAddition);
-  //     }
-  //   });
-  // };
-
   getOverallData(data: any) {
     this.stepValid[0] = true;
     this.output.title = data.title;
@@ -110,6 +111,8 @@ export class AppointmentCreateComponent implements OnInit {
     this.output.deadline = data.deadline;
     this.output.location = data.location;
     this.output.maxEnrollments = data.maxEnrollments;
+
+    this.doneForms.overall = true;
 
     this.stepper.next();
   }
@@ -119,6 +122,8 @@ export class AppointmentCreateComponent implements OnInit {
     this.output.driverAddition = data.driverAddition;
     this.output.additions = data.additions;
 
+    this.doneForms.additions = true;
+
     this.stepper.next();
   }
 
@@ -127,6 +132,12 @@ export class AppointmentCreateComponent implements OnInit {
     this.output.link = data.link;
     this.output.description = data.description;
 
+    this.doneForms.link = true;
+
     this.stepper.next();
+  }
+
+  back() {
+    this.stepper.previous();
   }
 }

--- a/src/app/components/termin/appointment-settings/appointment-settings.component.html
+++ b/src/app/components/termin/appointment-settings/appointment-settings.component.html
@@ -17,7 +17,9 @@
         <mat-tab label="Allgemein">
           <app-overall-data
             (save)="saveOverall($event)"
-            [appointment]="appointment">
+            [appointment]="appointment"
+            isEdit=" true"
+          >
           </app-overall-data>
         </mat-tab>
         <mat-tab label="Zusätze">

--- a/src/app/components/termin/appointment-settings/appointment-settings.component.html
+++ b/src/app/components/termin/appointment-settings/appointment-settings.component.html
@@ -32,7 +32,7 @@
             [appointment]="appointment">
           </app-link-data>
         </mat-tab>
-        <mat-tab label="Adminsitration">
+        <mat-tab label="Administration">
           <app-administrator
             (save)="saveAdministrators($event)"
             [appointment]="appointment">

--- a/src/app/components/termin/enrollment/enrollment-create/enrollment-create.component.html
+++ b/src/app/components/termin/enrollment/enrollment-create/enrollment-create.component.html
@@ -1,5 +1,6 @@
 <mat-card class="form float high">
-  <mat-card-title class="headline" id="title">
+  <mat-card-title class="headline"
+                  id="title">
     Anmelden
   </mat-card-title>
 

--- a/src/app/components/termin/form/additions/additions.component.html
+++ b/src/app/components/termin/form/additions/additions.component.html
@@ -60,8 +60,8 @@
       <button (click)="goBack()"
               class="left"
               color="primary"
-              disableRipple
               mat-button
+              disableRipple
               type="button">
         Zurück
       </button>

--- a/src/app/components/termin/form/additions/additions.component.html
+++ b/src/app/components/termin/form/additions/additions.component.html
@@ -1,21 +1,30 @@
 <form [formGroup]="event">
-  <span class="info">
-    Zusätze, welche beim Anmelden mit Ja/Nein beantwortet werden
-  </span>
-  <ng-container id="additionList">
+
+  <span class="form-component-title">Zusätze</span>
+
+  <mat-card-content>
     <div class="tooltip-container">
-      <mat-checkbox formControlName="driverAddition">
-        Fahrer
-      </mat-checkbox>
-      <!--suppress TypeScriptUnresolvedFunction -->
-      <mat-icon #driverAdditionTooltip="matTooltip"
-                (click)="driverAdditionTooltip.toggle()"
-                class="tooltip"
-                matTooltip="{{ 'Hierbei können sich Teilnehmer als Fahrer melden. Sie geben unter Anderem die ' +
+      <div class="checkbox-standalone">
+        <mat-checkbox formControlName="driverAddition">
+          Fahrerzusatz
+        </mat-checkbox>
+        <!--suppress TypeScriptUnresolvedFunction -->
+        <mat-icon #driverAdditionTooltip="matTooltip"
+                  (click)="driverAdditionTooltip.toggle()"
+                  class="tooltip"
+                  matTooltip="{{ 'Hierbei können sich Teilnehmer als Fahrer melden. Sie geben unter Anderem die ' +
                        'Anzahl freier Plätze ein und in welche Richtung sie fahren.'}}">
-        info
-      </mat-icon>
+          info
+        </mat-icon>
+      </div>
     </div>
+
+    <div class="info after-input last">
+      Zusatz zum Verwalten von Fahrern und Mitfahrern.
+    </div>
+
+    <span class="form-component-title">Weitere Zusätze</span>
+
     <div class="addition-wrapper">
       <!--suppress AngularInvalidExpressionResultType, JSUnusedGlobalSymbols -->
       <div *ngFor="let addition of event.controls.additions.controls; let i = index"
@@ -32,16 +41,36 @@
           </mat-icon>
         </mat-form-field>
       </div>
+
+      <button (click)="addAddition()"
+              class="solo"
+              mat-button>
+        <mat-icon>library_add</mat-icon>
+        Weiterer Zusatz
+      </button>
     </div>
-  </ng-container>
-  <button (click)="addAddition()"
-          class="solo"
-          mat-stroked-button>
-    Hinzufügen
-  </button>
-  <button (click)="saveFnc()"
-          [disabled]="sameValues && appointment !== undefined"
-          mat-raised-button>
-    {{ button === 'Speichern' ? button : (hasAdditions() ? button : 'Nein danke') }}
-  </button>
+  </mat-card-content>
+
+  <div class="info">
+    Zusätze, welche beim Anmelden optional angekreutzt werden können.
+  </div>
+
+  <mat-card-actions class="double">
+    <div>
+      <button (click)="goBack()"
+              class="left"
+              color="primary"
+              mat-button
+              type="button">
+        Zurück
+      </button>
+    </div>
+    <button
+      (click)="saveFnc()"
+      [disabled]="sameValues && appointment !== undefined"
+      color="primary"
+      mat-raised-button>
+      {{ button === 'Speichern' ? button : (hasAdditions() ? button : 'Nein danke') }}
+    </button>
+  </mat-card-actions>
 </form>

--- a/src/app/components/termin/form/additions/additions.component.html
+++ b/src/app/components/termin/form/additions/additions.component.html
@@ -60,6 +60,7 @@
       <button (click)="goBack()"
               class="left"
               color="primary"
+              disableRipple
               mat-button
               type="button">
         Zurück

--- a/src/app/components/termin/form/additions/additions.component.scss
+++ b/src/app/components/termin/form/additions/additions.component.scss
@@ -1,20 +1,5 @@
-form {
-  .addition-wrapper {
-    margin-top: 15px;
-  }
-
-  .mat-form-field {
-    width: 100%;
-  }
-
-  .solo {
-    font-size: .8em;
-    padding: 0 10px;
-    line-height: 30px;
-  }
-
-  button:last-of-type {
-    margin-top: 15px;
-    display: block;
+.addition-wrapper {
+  button {
+    padding: 0px;
   }
 }

--- a/src/app/components/termin/form/additions/additions.component.ts
+++ b/src/app/components/termin/form/additions/additions.component.ts
@@ -11,6 +11,8 @@ export class AdditionsComponent implements OnInit {
 
   @Output()
   save = new EventEmitter<any>();
+  @Output()
+  back = new EventEmitter<any>();
   @Input()
   public appointment: IAppointmentModel;
   @Input()
@@ -43,18 +45,6 @@ export class AdditionsComponent implements OnInit {
     );
   }
 
-  private parseIntoForm() {
-    this.appointment.additions.forEach(fAddition => {
-      this.addAddition(fAddition.name);
-    });
-
-    if (this.appointment.additions.length === 0) {
-      this.addAddition();
-    }
-
-    this.event.get('driverAddition').setValue(this.appointment.driverAddition);
-  }
-
   saveFnc() {
     if (this.event.valid) {
       const data = {
@@ -65,12 +55,6 @@ export class AdditionsComponent implements OnInit {
       this.save.emit(data);
     }
   }
-
-  private parseAdditionsFromForm() {
-    const additions = [];
-    this.event.controls.additions.controls.forEach(field => field.value != null ? additions.push({name: field.value}) : '');
-    return additions;
-  };
 
   public addAddition(value: string | null = null) {
     return (this.event.controls.additions as FormArray).push(new FormControl(value));
@@ -84,4 +68,26 @@ export class AdditionsComponent implements OnInit {
     return this.event.controls.additions.controls.some(addition => addition.value !== null)
       || this.event.get('driverAddition').value;
   }
+
+  public goBack() {
+    this.back.emit();
+  }
+
+  private parseIntoForm() {
+    this.appointment.additions.forEach(fAddition => {
+      this.addAddition(fAddition.name);
+    });
+
+    if (this.appointment.additions.length === 0) {
+      this.addAddition();
+    }
+
+    this.event.get('driverAddition').setValue(this.appointment.driverAddition);
+  }
+
+  private parseAdditionsFromForm() {
+    const additions = [];
+    this.event.controls.additions.controls.forEach(field => field.value != null ? additions.push({name: field.value}) : '');
+    return additions;
+  };
 }

--- a/src/app/components/termin/form/additions/additions.module.ts
+++ b/src/app/components/termin/form/additions/additions.module.ts
@@ -2,7 +2,16 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {AdditionsComponent} from './additions.component';
 import {ReactiveFormsModule} from '@angular/forms';
-import {MatButtonModule, MatCheckboxModule, MatFormFieldModule, MatIconModule, MatInputModule, MatTooltipModule} from '@angular/material';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatDividerModule,
+  MatFormFieldModule,
+  MatIconModule,
+  MatInputModule,
+  MatTooltipModule
+} from '@angular/material';
 
 
 @NgModule({
@@ -19,7 +28,9 @@ import {MatButtonModule, MatCheckboxModule, MatFormFieldModule, MatIconModule, M
     MatTooltipModule,
     MatFormFieldModule,
     MatInputModule,
-    MatButtonModule
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule
   ]
 })
 export class AdditionsModule {

--- a/src/app/components/termin/form/link-data/link-data.component.html
+++ b/src/app/components/termin/form/link-data/link-data.component.html
@@ -1,23 +1,38 @@
 <form [formGroup]="event">
-  <span class="info">Eigener URL Pfad zum Termin</span>
-  <mat-form-field class="">
-    <label for="link">
-      <input (change)="checkLink()"
-             formControlName="link"
-             id="link"
-             matInput
-             placeholder="Wunschlink">
-    </label>
-    <mat-hint *ngIf="event.get('link').value !== ''
+
+  <div class="form-component-title">Link Infos</div>
+
+  <mat-card-content>
+    <mat-form-field class="">
+      <label for="link">
+        <input (change)="checkLink()"
+               formControlName="link"
+               id="link"
+               matInput
+               placeholder="Wunschlink">
+      </label>
+
+      <button mat-icon-button matSuffix type="button">
+        <!--suppress TypeScriptUnresolvedFunction -->
+        <mat-icon #username="matTooltip"
+                  (click)="username.toggle()"
+                  class="tooltip"
+                  matTooltip="Wird kein Wunschlink angegeben wird ein Link aus 5 zufälligen Groß-, Kleinbuchstaben und
+                  Zahlen generiert">
+          info
+        </mat-icon>
+      </button>
+
+      <mat-hint *ngIf="event.get('link').value !== ''
                   && event.get('link').value !== null"
-              class="small">
-      {{urlService.getHostname()}}{{event.get('link').value | urlEncode}}
-    </mat-hint>
-    <mat-error>{{ this.getLinkErrorMessage() }}</mat-error>
-  </mat-form-field>
-  <mat-form-field>
-    <div class="tooltip-container">
-      <label for="description">
+                class="small">
+        {{urlService.getHostname()}}{{event.get('link').value | urlEncode}}
+      </mat-hint>
+      <mat-error>{{ this.getLinkErrorMessage() }}</mat-error>
+    </mat-form-field>
+    <mat-form-field>
+      <div class="tooltip-container">
+        <label for="description">
           <textarea #description
                     formControlName="description"
                     id="description"
@@ -26,25 +41,42 @@
                     placeholder="Zusatzinformationen"
                     required>
           </textarea>
-      </label>
-      <!--suppress TypeScriptUnresolvedFunction -->
-      <mat-icon #descriptionTooltip="matTooltip"
-                (click)="descriptionTooltip.toggle()"
-                class="tooltip"
-                matTooltip="{{'Dieser Text wird unter Anderem beim Versenden des Anmeldelinks als Linkvorschau angezeigt.'}}">
-        info
-      </mat-icon>
+        </label>
+        <!--suppress TypeScriptUnresolvedFunction -->
+        <mat-icon #descriptionTooltip="matTooltip"
+                  (click)="descriptionTooltip.toggle()"
+                  class="tooltip"
+                  matTooltip="{{'Dieser Text wird unter Anderem beim Versenden des Anmeldelinks als Linkvorschau angezeigt.'}}">
+          info
+        </mat-icon>
+      </div>
+      <mat-hint *ngIf="description.value.length < 10"
+                align="start">
+        Noch mindestens {{10 - description.value.length}} Zeichen
+      </mat-hint>
+      <mat-error>{{ this.getDescriptionErrorMessage() }}</mat-error>
+    </mat-form-field>
+  </mat-card-content>
+
+  <span class="info">Eigener URL Pfad zum Termin und weitere Informationen.</span>
+
+  <mat-card-actions class="double">
+    <div>
+      <button (click)="goBack()"
+              class="left"
+              color="primary"
+              disableRipple
+              mat-button
+              type="button">
+        Zurück
+      </button>
     </div>
-    <mat-hint *ngIf="description.value.length < 10"
-              align="start">
-      Noch mindestens {{10 - description.value.length}} Zeichen
-    </mat-hint>
-    <mat-error>{{ this.getDescriptionErrorMessage() }}</mat-error>
-  </mat-form-field>
-  <button
-    (click)="saveFnc()"
-    [disabled]="sameValues && appointment !== undefined"
-    mat-raised-button>
-    {{button}}
-  </button>
+    <button
+      (click)="saveFnc()"
+      [disabled]="sameValues && appointment !== undefined"
+      color="primary"
+      mat-raised-button>
+      {{button}}
+    </button>
+  </mat-card-actions>
 </form>

--- a/src/app/components/termin/form/link-data/link-data.component.ts
+++ b/src/app/components/termin/form/link-data/link-data.component.ts
@@ -12,6 +12,8 @@ export class LinkDataComponent implements OnInit {
 
   @Output()
   save = new EventEmitter<any>();
+  @Output()
+  back = new EventEmitter<any>();
   @Input()
   public appointment: IAppointmentModel;
   @Input()
@@ -42,15 +44,6 @@ export class LinkDataComponent implements OnInit {
     );
   }
 
-  private parseIntoForm() {
-    this.event.setValue({
-      link: this.appointment.link,
-      description: this.appointment.description,
-    });
-
-    this.checkLink();
-  }
-
   public saveFnc() {
     if (this.get('description').value.length >= 10 && !this.get('link').hasError('inUse')) {
       const data = {
@@ -60,6 +53,10 @@ export class LinkDataComponent implements OnInit {
 
       this.save.emit(data);
     }
+  }
+
+  public goBack() {
+    this.back.emit();
   }
 
   getLinkErrorMessage(): string {
@@ -82,12 +79,21 @@ export class LinkDataComponent implements OnInit {
     }
   }
 
-  private get(str: string) {
-    return this.event.get(str);
-  }
-
   public updateErrors(err) {
     this.get(err.attr).setErrors({[err.error]: true});
+  }
+
+  private parseIntoForm() {
+    this.event.setValue({
+      link: this.appointment.link,
+      description: this.appointment.description,
+    });
+
+    this.checkLink();
+  }
+
+  private get(str: string) {
+    return this.event.get(str);
   }
 }
 

--- a/src/app/components/termin/form/link-data/link-data.module.ts
+++ b/src/app/components/termin/form/link-data/link-data.module.ts
@@ -2,7 +2,7 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {LinkDataComponent} from './link-data.component';
 import {ReactiveFormsModule} from '@angular/forms';
-import {MatButtonModule, MatIconModule, MatInputModule, MatTooltipModule} from '@angular/material';
+import {MatButtonModule, MatCardModule, MatIconModule, MatInputModule, MatTooltipModule} from '@angular/material';
 import {ApplicationPipesModule} from '../../../../pipes/application-pipes.module';
 
 
@@ -18,7 +18,8 @@ import {ApplicationPipesModule} from '../../../../pipes/application-pipes.module
     ApplicationPipesModule,
     MatTooltipModule,
     MatButtonModule,
-    MatIconModule
+    MatIconModule,
+    MatCardModule
   ]
 })
 export class LinkDataModule {

--- a/src/app/components/termin/form/overall-data/overall-data.component.html
+++ b/src/app/components/termin/form/overall-data/overall-data.component.html
@@ -72,7 +72,7 @@
   </div>
 
   <mat-card-actions class="double">
-    <div>
+    <div *ngIf="!isEdit">
       <button [routerLink]="'/dashboard'"
               class="left"
               color="primary"
@@ -80,6 +80,17 @@
               mat-button
               type="button">
         Abbrechen
+      </button>
+    </div>
+    <div *ngIf="isEdit">
+      <button [queryParamsHandling]="'preserve'"
+              [routerLink]="'/enroll' "
+              class="left"
+              color="primary"
+              disableRipple
+              mat-button
+              type="button">
+        Zurück
       </button>
     </div>
     <button

--- a/src/app/components/termin/form/overall-data/overall-data.component.html
+++ b/src/app/components/termin/form/overall-data/overall-data.component.html
@@ -13,6 +13,7 @@
                placeholder="Titel"
                required>
       </label>
+      <mat-error id="title-error">{{ getErrorMessage('title') }}</mat-error>
     </mat-form-field>
     <mat-form-field class="example-full-width">
       <label for="date">
@@ -29,6 +30,7 @@
       <!--    </mat-datepicker-toggle>-->
       <!--    <ngx-mat-datetime-picker #date>-->
       <!--    </ngx-mat-datetime-picker>-->
+      <mat-error id="date-error">{{ getErrorMessage('date') }}</mat-error>
     </mat-form-field>
     <mat-form-field class="example-full-width">
       <label for="deadline">
@@ -53,6 +55,7 @@
                placeholder="Ort"
                required>
       </label>
+      <mat-error id="location-error">{{ getErrorMessage('location') }}</mat-error>
     </mat-form-field>
     <mat-form-field class="">
       <label for="maxEnrollments">

--- a/src/app/components/termin/form/overall-data/overall-data.component.html
+++ b/src/app/components/termin/form/overall-data/overall-data.component.html
@@ -64,17 +64,19 @@
     </mat-form-field>
   </mat-card-content>
 
-  <div class="info long">
+  <div class="info">
     Gebe die wichtigsten Informationen zu deinem Termin an.
   </div>
 
   <mat-card-actions class="double">
     <div>
-      <button class="left"
+      <button [routerLink]="'/dashboard'"
+              class="left"
               color="primary"
+              disableRipple
               mat-button
               type="button">
-        Zurück
+        Abbrechen
       </button>
     </div>
     <button

--- a/src/app/components/termin/form/overall-data/overall-data.component.html
+++ b/src/app/components/termin/form/overall-data/overall-data.component.html
@@ -1,66 +1,88 @@
 <form [formGroup]="event">
-  <span class="info">Kerninformationen</span>
-  <mat-form-field class="">
-    <label for="title">
-      <input formControlName="title"
-             id="title"
-             matInput
-             placeholder="Titel"
-             required>
-    </label>
-  </mat-form-field>
-  <mat-form-field class="example-full-width">
-    <label for="date">
-      <input matInput
-             formControlName="date"
-             id="date"
-             type="datetime-local"
-             placeholder="Datum"
-             required>
-    </label>
-    <!--    <mat-datepicker-toggle-->
-    <!--      [for]="date"-->
-    <!--      matSuffix>-->
-    <!--    </mat-datepicker-toggle>-->
-    <!--    <ngx-mat-datetime-picker #date>-->
-    <!--    </ngx-mat-datetime-picker>-->
-  </mat-form-field>
-  <mat-form-field class="example-full-width">
-    <label for="deadline">
-      <input id="deadline"
-             formControlName="deadline"
-             type="datetime-local"
-             matInput
-             placeholder="Anmeldefrist">
-    </label>
-    <!--    <mat-datepicker-toggle-->
-    <!--      [for]="deadlinePicker"-->
-    <!--      matSuffix>-->
-    <!--    </mat-datepicker-toggle>-->
-    <!--    <ngx-mat-datetime-picker #deadlinePicker>-->
-    <!--    </ngx-mat-datetime-picker>-->
-  </mat-form-field>
-  <mat-form-field class="">
-    <label for="location">
-      <input formControlName="location"
-             id="location"
-             matInput
-             placeholder="Ort"
-             required>
-    </label>
-  </mat-form-field>
-  <mat-form-field class="">
-    <label for="maxEnrollments">
-      <input formControlName="maxEnrollments"
-             id="maxEnrollments"
-             matInput
-             placeholder="Maximale Teilnehmer">
-    </label>
-  </mat-form-field>
-  <button
-    (click)="saveFnc()"
-    [disabled]="valuesChanged && appointment !== undefined"
-    mat-raised-button>
-    {{button}}
-  </button>
+
+  <span class="form-component-title">
+    Allgemein
+  </span>
+
+  <mat-card-content>
+    <mat-form-field class="">
+      <label for="title">
+        <input formControlName="title"
+               id="title"
+               matInput
+               placeholder="Titel"
+               required>
+      </label>
+    </mat-form-field>
+    <mat-form-field class="example-full-width">
+      <label for="date">
+        <input formControlName="date"
+               id="date"
+               matInput
+               placeholder="Datum"
+               required
+               type="datetime-local">
+      </label>
+      <!--    <mat-datepicker-toggle-->
+      <!--      [for]="date"-->
+      <!--      matSuffix>-->
+      <!--    </mat-datepicker-toggle>-->
+      <!--    <ngx-mat-datetime-picker #date>-->
+      <!--    </ngx-mat-datetime-picker>-->
+    </mat-form-field>
+    <mat-form-field class="example-full-width">
+      <label for="deadline">
+        <input formControlName="deadline"
+               id="deadline"
+               matInput
+               placeholder="Anmeldefrist"
+               type="datetime-local">
+      </label>
+      <!--    <mat-datepicker-toggle-->
+      <!--      [for]="deadlinePicker"-->
+      <!--      matSuffix>-->
+      <!--    </mat-datepicker-toggle>-->
+      <!--    <ngx-mat-datetime-picker #deadlinePicker>-->
+      <!--    </ngx-mat-datetime-picker>-->
+    </mat-form-field>
+    <mat-form-field class="">
+      <label for="location">
+        <input formControlName="location"
+               id="location"
+               matInput
+               placeholder="Ort"
+               required>
+      </label>
+    </mat-form-field>
+    <mat-form-field class="">
+      <label for="maxEnrollments">
+        <input formControlName="maxEnrollments"
+               id="maxEnrollments"
+               matInput
+               placeholder="Maximale Teilnehmer">
+      </label>
+    </mat-form-field>
+  </mat-card-content>
+
+  <div class="info long">
+    Gebe die wichtigsten Informationen zu deinem Termin an.
+  </div>
+
+  <mat-card-actions class="double">
+    <div>
+      <button class="left"
+              color="primary"
+              mat-button
+              type="button">
+        Zurück
+      </button>
+    </div>
+    <button
+      (click)="saveFnc()"
+      [disabled]="valuesChanged && appointment !== undefined"
+      color="primary"
+      mat-raised-button>
+      {{button}}
+    </button>
+  </mat-card-actions>
 </form>

--- a/src/app/components/termin/form/overall-data/overall-data.component.ts
+++ b/src/app/components/termin/form/overall-data/overall-data.component.ts
@@ -3,6 +3,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {IAppointmentModel} from '../../../../models/IAppointment.model';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material';
 import {MAT_MOMENT_DATE_ADAPTER_OPTIONS, MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
+import {DatePipe} from '@angular/common';
 
 @Component({
   selector: 'app-overall-data',
@@ -31,7 +32,7 @@ export class OverallDataComponent implements OnInit {
   public event: FormGroup;
   public valuesChanged = true;
 
-  constructor(private formBuilder: FormBuilder, private _adapter: DateAdapter<any>) {
+  constructor(private formBuilder: FormBuilder, private _adapter: DateAdapter<any>, private datePipe: DatePipe) {
   }
 
   ngOnInit() {
@@ -50,24 +51,6 @@ export class OverallDataComponent implements OnInit {
     }
   }
 
-  private parseOverallData() {
-    this.event.setValue({
-      title: this.appointment.title,
-      date: this.appointment.date,
-      deadline: this.appointment.deadline,
-      location: this.appointment.location,
-      maxEnrollments: this.appointment.maxEnrollments
-    });
-
-    const eventSnapshot = this.event.value;
-
-    this.event.valueChanges.subscribe(
-      result => {
-        this.valuesChanged = JSON.stringify(result) === JSON.stringify(eventSnapshot);
-      }
-    );
-  }
-
   public saveFnc() {
     if (this.event.valid) {
       const data = {
@@ -80,6 +63,30 @@ export class OverallDataComponent implements OnInit {
 
       this.save.emit(data);
     }
+  }
+
+  private parseOverallData() {
+    const _deadline = new Date(this.appointment.deadline);
+    const deadline = this.datePipe.transform(_deadline, 'yyyy-MM-ddThh:mm');
+
+    const _date = new Date(this.appointment.deadline);
+    const date = this.datePipe.transform(_date, 'yyyy-MM-ddThh:mm');
+
+    this.event.setValue({
+      title: this.appointment.title,
+      date,
+      deadline,
+      location: this.appointment.location,
+      maxEnrollments: this.appointment.maxEnrollments
+    });
+
+    const eventSnapshot = this.event.value;
+
+    this.event.valueChanges.subscribe(
+      result => {
+        this.valuesChanged = JSON.stringify(result) === JSON.stringify(eventSnapshot);
+      }
+    );
   }
 
   private get(str: string) {

--- a/src/app/components/termin/form/overall-data/overall-data.component.ts
+++ b/src/app/components/termin/form/overall-data/overall-data.component.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {IAppointmentModel} from '../../../../models/IAppointment.model';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material';
 import {MAT_MOMENT_DATE_ADAPTER_OPTIONS, MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
@@ -39,11 +39,11 @@ export class OverallDataComponent implements OnInit {
     this._adapter.setLocale('de');
 
     this.event = this.formBuilder.group({
-      title: ['', Validators.required],
-      date: ['', Validators.required],
-      deadline: [''],
-      location: ['', Validators.required],
-      maxEnrollments: [''],
+      title: new FormControl('', [Validators.required]),
+      date: new FormControl('', [Validators.required]),
+      deadline: new FormControl(''),
+      location: new FormControl('', [Validators.required]),
+      maxEnrollments: new FormControl(''),
     });
 
     if (this.appointment !== undefined) {
@@ -62,6 +62,14 @@ export class OverallDataComponent implements OnInit {
       };
 
       this.save.emit(data);
+    }
+  }
+
+  public getErrorMessage(str: string) {
+    if (str !== '') {
+      if (this.get(str).hasError('required')) {
+        return 'Erforderlich';
+      }
     }
   }
 

--- a/src/app/components/termin/form/overall-data/overall-data.component.ts
+++ b/src/app/components/termin/form/overall-data/overall-data.component.ts
@@ -28,6 +28,8 @@ export class OverallDataComponent implements OnInit {
   public appointment: IAppointmentModel;
   @Input()
   public button = 'Speichern';
+  @Input()
+  public isEdit = false;
 
   public event: FormGroup;
   public valuesChanged = true;

--- a/src/app/components/termin/form/overall-data/overall-data.module.ts
+++ b/src/app/components/termin/form/overall-data/overall-data.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
+import {CommonModule, DatePipe} from '@angular/common';
 import {OverallDataComponent} from './overall-data.component';
 import {ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatDatepickerModule, MatFormFieldModule, MatInputModule, MatProgressSpinnerModule} from '@angular/material';
@@ -18,7 +18,8 @@ import {MatButtonModule, MatDatepickerModule, MatFormFieldModule, MatInputModule
     MatDatepickerModule,
     MatButtonModule,
     MatProgressSpinnerModule
-  ]
+  ],
+  providers: [DatePipe]
 })
 export class OverallDataModule {
 }

--- a/src/app/components/termin/form/overall-data/overall-data.module.ts
+++ b/src/app/components/termin/form/overall-data/overall-data.module.ts
@@ -2,7 +2,15 @@ import {NgModule} from '@angular/core';
 import {CommonModule, DatePipe} from '@angular/common';
 import {OverallDataComponent} from './overall-data.component';
 import {ReactiveFormsModule} from '@angular/forms';
-import {MatButtonModule, MatDatepickerModule, MatFormFieldModule, MatInputModule, MatProgressSpinnerModule} from '@angular/material';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatDatepickerModule,
+  MatFormFieldModule,
+  MatInputModule,
+  MatProgressSpinnerModule
+} from '@angular/material';
+import {STEPPER_GLOBAL_OPTIONS} from '@angular/cdk/stepper';
 
 
 @NgModule({
@@ -17,9 +25,14 @@ import {MatButtonModule, MatDatepickerModule, MatFormFieldModule, MatInputModule
     MatInputModule,
     MatDatepickerModule,
     MatButtonModule,
-    MatProgressSpinnerModule
+    MatProgressSpinnerModule,
+    MatCardModule
   ],
-  providers: [DatePipe]
+  providers: [DatePipe,
+    {
+      provide: STEPPER_GLOBAL_OPTIONS,
+      useValue: {displayDefaultIndicatorType: false}
+    }]
 })
 export class OverallDataModule {
 }

--- a/src/app/components/termin/form/overall-data/overall-data.module.ts
+++ b/src/app/components/termin/form/overall-data/overall-data.module.ts
@@ -11,6 +11,7 @@ import {
   MatProgressSpinnerModule
 } from '@angular/material';
 import {STEPPER_GLOBAL_OPTIONS} from '@angular/cdk/stepper';
+import {RouterModule} from '@angular/router';
 
 
 @NgModule({
@@ -26,7 +27,8 @@ import {STEPPER_GLOBAL_OPTIONS} from '@angular/cdk/stepper';
     MatDatepickerModule,
     MatButtonModule,
     MatProgressSpinnerModule,
-    MatCardModule
+    MatCardModule,
+    RouterModule
   ],
   providers: [DatePipe,
     {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -307,6 +307,16 @@ mat-icon {
   }
 }
 
+.form-component-title {
+  width: 100%;
+  text-align: left;
+  font-weight: bolder;
+  margin-bottom: 1.125em;
+  display: block;
+  color: $secondary;
+  font-size: 1.125em;
+}
+
 .bar {
   background-color: $secondary;
   color: white !important;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1170,7 +1170,7 @@ $ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
 .input-with-button-wrapper {
   mat-form-field {
     padding: 0 10px 0 0 !important;
-    width: calc(70% - 15px) !important;
+    width: calc(60% - 15px) !important;
   }
 
   button {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -310,6 +310,7 @@ mat-icon {
 .form-component-title {
   width: 100%;
   text-align: left;
+  text-align-last: left;
   font-weight: bolder;
   margin-bottom: 1.125em;
   display: block;
@@ -640,8 +641,6 @@ mat-card {
   }
 
   &.form {
-    text-align: center;
-
     mat-card-content {
       mat-form-field {
         width: 100%;
@@ -656,7 +655,7 @@ mat-card {
 
     .info {
       text-align: left;
-      margin: 26px 0 0;
+      margin: 24px 0 0;
       font-size: 14px;
       width: 75%;
       max-width: 350px;
@@ -667,6 +666,10 @@ mat-card {
 
       &.long {
         width: 80%;
+      }
+
+      &.last {
+        padding-bottom: 1.25em;
       }
     }
 
@@ -1022,30 +1025,34 @@ $ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
   }
 }
 
-.info {
-  display: block;
-  margin: 5px auto 15px;
-  font-size: 1em;
-  color: #646464;
-  text-align: center;
-
-  &.long {
-    width: 100%;
-  }
-
-  &.spacing {
-    margin-top: 25px;
-  }
-
-  &.small {
-    font-size: 0.85em;
-    max-width: 200px;
-  }
-
-  &.link {
-    text-decoration: underline;
-  }
-}
+//.info {
+//  display: block;
+//  margin: 5px auto 15px;
+//  font-size: 1em;
+//  color: #646464;
+//  text-align: center;
+//
+//  &.long {
+//    width: 100%;
+//  }
+//
+//  &.spacing {
+//    margin-top: 25px;
+//  }
+//
+//  &.small {
+//    font-size: 0.85em;
+//    max-width: 200px;
+//  }
+//
+//  &.link {
+//    text-decoration: underline;
+//  }
+//
+//  &.last {
+//    padding-bottom: 1.25em;
+//  }
+//}
 
 .progress-bar {
   display: block;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -214,7 +214,7 @@ mat-icon {
     & > div {
       width: 60%;
       height: 50%;
-      overflow: auto;
+      overflow-x: hidden;
       margin: 50px auto 0;
     }
 


### PR DESCRIPTION
Neast design adaptions for appointment create and edit form.
Now matches the appointment create flow, as well as the login flow (stepper or tab view).

Includes fix for #138. Correctly set current date values on edit.